### PR TITLE
write_addr_reg unused debug

### DIFF
--- a/rtl/cam_bram.v
+++ b/rtl/cam_bram.v
@@ -216,7 +216,7 @@ always @* begin
         end
         STATE_DELETE_2: begin
             // clear bit and write back
-            clear_bit = 1'b1 << write_addr;
+            clear_bit = 1'b1 << write_addr_reg;
             wr_en = 1'b1;
             if (write_delete_reg) begin
                 state_next = STATE_IDLE;
@@ -231,7 +231,7 @@ always @* begin
         end
         STATE_WRITE_2: begin
             // set bit and write back
-            set_bit = 1'b1 << write_addr;
+            set_bit = 1'b1 << write_addr_reg;
             wr_en = 1'b1;
             state_next = STATE_IDLE;
         end

--- a/rtl/cam_srl.v
+++ b/rtl/cam_srl.v
@@ -177,7 +177,7 @@ always @* begin
         end
         STATE_WRITE: begin
             // write entry
-            shift_en = 1'b1 << write_addr;
+            shift_en = 1'b1 << write_addr_reg;
 
             for (i = 0; i < SLICE_COUNT; i = i + 1) begin
                 shift_data[i] = count_reg == write_data_padded_reg[SLICE_WIDTH * i +: SLICE_WIDTH];
@@ -192,7 +192,7 @@ always @* begin
         end
         STATE_DELETE: begin
             // delete entry
-            shift_en = 1'b1 << write_addr;
+            shift_en = 1'b1 << write_addr_reg;
             shift_data = {SLICE_COUNT{1'b0}};
 
             if (count_reg == 0) begin


### PR DESCRIPTION
Debug the dangerous use of write_addr, should use write_addr_reg in your original code design. This bug could cause unexpected write/erase action if write_addr is not stable in the next clk of write_enable.
Your testbench may need to be modified, too. But I can't run your testbench on my computer. :D
Testbench modification may like this:
        # write some data
        write_addr.next = 0
        write_data.next = 0x0123456789ABCDEF
        write_delete.next = 0
        write_enable.next = 1
        yield clk.posedge
        write_enable.next = 0
        yield clk.posedge
to
        # write some data
        write_addr.next = 0
        write_data.next = 0x0123456789ABCDEF
        write_delete.next = 0
        write_enable.next = 1
        yield clk.posedge
        write_addr.next = 0
        write_data.next = 0
        write_delete.next = 0
        write_enable.next = 0
        yield clk.posedge
THANKS FOR YOUR PROJECT A LOT!